### PR TITLE
Minor fixes

### DIFF
--- a/content/guest/nwuttke.md
+++ b/content/guest/nwuttke.md
@@ -1,8 +1,8 @@
 +++
-Title = "Nicolai Wuttke"
-Twitter = "@lethal_guitar"
+Title = "Nikolai Wuttke"
+Twitter = "lethal_guitar"
 GitHub = "lethal-guitar"
 Website = "https://lethalguitar.wordpress.com/"
-Thumbnail = "img/guest/nicolai-wuttke.jpg"
+Thumbnail = "img/guest/nikolai-wuttke.jpg"
 +++
 Rob and Jason are joined by Nikolai Wuttke. They first discuss a blog post series from Raymond Chen on coroutines and the upcoming pure virtual C++ conference. Then they talk to Nikolai Wuttke about Rigel Engine, a modern C++ reimplementation of Duke Nukem II.


### PR DESCRIPTION
Thanks again for having me on the show! 🙂

I noticed two minor issues on the episode's page, which should be fixed by this PR:

* Missing image due to misspelling in the image URL
* Misspelled name (only in one place)

![Screenshot_20210409-192046](https://user-images.githubusercontent.com/1821027/114219308-c4aa2480-996a-11eb-9f2f-b4a1f94a2e70.png)